### PR TITLE
Add travis protractor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 os:
   - linux
 services:
-  - dockeri
+  - docker
 language: java
 node_js:
   - "4.2.1"
@@ -10,7 +10,6 @@ jdk:
 before_install:
   - sudo /etc/init.d/postgresql stop
 install:
-  - set -ev
   - java -version
   - ./gradlew --version
   - npm install -g bower

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,29 @@
+os:
+  - linux
+services:
+  - dockeri
 language: java
 node_js:
   - "4.2.1"
 jdk:
   - oraclejdk8
+before_install:
+  - sudo /etc/init.d/postgresql stop
 install:
   - set -ev
   - java -version
   - ./gradlew --version
   - npm install -g bower
   - npm install -g grunt-cli
+  - npm install
   - ./gradlew assemble
 script:
   - ./gradlew check
+  - docker-compose up -d
+  - sleep 20s
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
+  - ./gradlew bootRun &
+  - bootPid=$!
+  - sleep 120s
+  - grunt itest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+21points-dev-postgresql:
+  container_name: 21points-dev-postgresql
+  image: postgres:9.4.5
+  # volumes:
+  # - ~/volumes/jhipster/21points/dev-postgresql/:/var/lib/postgresql/
+  environment:
+  - POSTGRES_USER=health
+  - POSTGRES_PASSWORD=health
+  ports:
+  - "5432:5432"
+

--- a/src/test/javascript/protractor.conf.js
+++ b/src/test/javascript/protractor.conf.js
@@ -16,6 +16,8 @@ exports.config = {
         'phantomjs.ghostdriver.cli.args': ['--loglevel=DEBUG']
     },
 
+    directConnect: true,
+    
     baseUrl: 'http://localhost:8080/',
 
     framework: 'jasmine2',


### PR DESCRIPTION
- use linux instead of osx in travis build : linux seems to be more stable than osx (download npm, lib...)
- use docker-compose to param and start psql
- adding directConnect to true : because there is `Error: Timed out waiting for the WebDriver server` => https://github.com/angular/angular-phonecat/issues/276

There are some errors in log during protractor tests, maybe it's normal ?
