### PR TITLE
Change entities to use UUID for IDs

### DIFF
--- a/src/main/java/org/jhipster/health/domain/BloodPressure.java
+++ b/src/main/java/org/jhipster/health/domain/BloodPressure.java
@@ -10,6 +10,7 @@ import javax.validation.constraints.NotNull;
 import java.io.Serializable;
 import java.time.ZonedDateTime;
 import java.util.Objects;
+import java.util.UUID;
 
 /**
  * A BloodPressure.
@@ -23,9 +24,8 @@ public class BloodPressure implements Serializable {
     private static final long serialVersionUID = 1L;
 
     @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "sequenceGenerator")
-    @SequenceGenerator(name = "sequenceGenerator")
-    private Long id;
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private UUID id;
 
     @NotNull
     @Column(name = "jhi_timestamp", nullable = false)
@@ -54,11 +54,11 @@ public class BloodPressure implements Serializable {
 
     // jhipster-needle-entity-add-field - JHipster will add fields here, do not remove
 
-    public Long getId() {
+    public UUID getId() {
         return id;
     }
 
-    public void setId(Long id) {
+    public void setId(UUID id) {
         this.id = id;
     }
 

--- a/src/main/java/org/jhipster/health/domain/PersistentAuditEvent.java
+++ b/src/main/java/org/jhipster/health/domain/PersistentAuditEvent.java
@@ -6,6 +6,7 @@ import java.io.Serializable;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * Persist AuditEvent managed by the Spring Boot actuator.
@@ -19,10 +20,9 @@ public class PersistentAuditEvent implements Serializable {
     private static final long serialVersionUID = 1L;
 
     @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "sequenceGenerator")
-    @SequenceGenerator(name = "sequenceGenerator")
+    @GeneratedValue(strategy = GenerationType.AUTO)
     @Column(name = "event_id")
-    private Long id;
+    private UUID id;
 
     @NotNull
     @Column(nullable = false)
@@ -40,11 +40,11 @@ public class PersistentAuditEvent implements Serializable {
     @CollectionTable(name = "jhi_persistent_audit_evt_data", joinColumns=@JoinColumn(name="event_id"))
     private Map<String, String> data = new HashMap<>();
 
-    public Long getId() {
+    public UUID getId() {
         return id;
     }
 
-    public void setId(Long id) {
+    public void setId(UUID id) {
         this.id = id;
     }
 

--- a/src/main/java/org/jhipster/health/domain/Points.java
+++ b/src/main/java/org/jhipster/health/domain/Points.java
@@ -11,6 +11,7 @@ import org.springframework.data.elasticsearch.annotations.Document;
 import java.io.Serializable;
 import java.time.LocalDate;
 import java.util.Objects;
+import java.util.UUID;
 
 /**
  * A Points.
@@ -24,9 +25,8 @@ public class Points implements Serializable {
     private static final long serialVersionUID = 1L;
 
     @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "sequenceGenerator")
-    @SequenceGenerator(name = "sequenceGenerator")
-    private Long id;
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private UUID id;
 
     @NotNull
     @Column(name = "jhi_date", nullable = false)
@@ -61,11 +61,11 @@ public class Points implements Serializable {
 
     // jhipster-needle-entity-add-field - JHipster will add fields here, do not remove
 
-    public Long getId() {
+    public UUID getId() {
         return id;
     }
 
-    public void setId(Long id) {
+    public void setId(UUID id) {
         this.id = id;
     }
 

--- a/src/main/java/org/jhipster/health/domain/Preferences.java
+++ b/src/main/java/org/jhipster/health/domain/Preferences.java
@@ -9,6 +9,7 @@ import javax.validation.constraints.*;
 import org.springframework.data.elasticsearch.annotations.Document;
 import java.io.Serializable;
 import java.util.Objects;
+import java.util.UUID;
 
 import org.jhipster.health.domain.enumeration.Units;
 
@@ -24,9 +25,8 @@ public class Preferences implements Serializable {
     private static final long serialVersionUID = 1L;
 
     @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "sequenceGenerator")
-    @SequenceGenerator(name = "sequenceGenerator")
-    private Long id;
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private UUID id;
 
     @NotNull
     @Min(value = 10)
@@ -43,11 +43,11 @@ public class Preferences implements Serializable {
     private User user;
 
     // jhipster-needle-entity-add-field - JHipster will add fields here, do not remove
-    public Long getId() {
+    public UUID getId() {
         return id;
     }
 
-    public void setId(Long id) {
+    public void setId(UUID id) {
         this.id = id;
     }
 

--- a/src/main/java/org/jhipster/health/domain/UUIDConverter.java
+++ b/src/main/java/org/jhipster/health/domain/UUIDConverter.java
@@ -1,0 +1,20 @@
+package org.jhipster.health.domain;
+
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+import java.util.UUID;
+
+/**
+ * JPA Convention to automatically convert UUID from Database (PostgreSQL) into Java and vice versa.
+ */
+@Converter(autoApply = true)
+public class UUIDConverter implements AttributeConverter<UUID, UUID> {
+    @Override
+    public UUID convertToDatabaseColumn(UUID attribute) {
+        return attribute;
+    }
+    @Override
+    public UUID convertToEntityAttribute(UUID dbData) {
+        return dbData;
+    }
+}

--- a/src/main/java/org/jhipster/health/domain/User.java
+++ b/src/main/java/org/jhipster/health/domain/User.java
@@ -1,5 +1,6 @@
 package org.jhipster.health.domain;
 
+import org.hibernate.annotations.Type;
 import org.jhipster.health.config.Constants;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -14,10 +15,7 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 import java.io.Serializable;
-import java.util.HashSet;
-import java.util.Locale;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 import java.time.Instant;
 
 /**
@@ -32,9 +30,8 @@ public class User extends AbstractAuditingEntity implements Serializable {
     private static final long serialVersionUID = 1L;
 
     @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "sequenceGenerator")
-    @SequenceGenerator(name = "sequenceGenerator")
-    private Long id;
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private UUID id;
 
     @NotNull
     @Pattern(regexp = Constants.LOGIN_REGEX)
@@ -96,11 +93,11 @@ public class User extends AbstractAuditingEntity implements Serializable {
     @BatchSize(size = 20)
     private Set<Authority> authorities = new HashSet<>();
 
-    public Long getId() {
+    public UUID getId() {
         return id;
     }
 
-    public void setId(Long id) {
+    public void setId(UUID id) {
         this.id = id;
     }
 

--- a/src/main/java/org/jhipster/health/domain/User.java
+++ b/src/main/java/org/jhipster/health/domain/User.java
@@ -1,22 +1,20 @@
 package org.jhipster.health.domain;
 
-import org.hibernate.annotations.Type;
-import org.jhipster.health.config.Constants;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.commons.lang3.StringUtils;
 import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
-import javax.validation.constraints.Email;
+import org.jhipster.health.config.Constants;
 
 import javax.persistence.*;
+import javax.validation.constraints.Email;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 import java.io.Serializable;
-import java.util.*;
 import java.time.Instant;
+import java.util.*;
 
 /**
  * A user.

--- a/src/main/java/org/jhipster/health/domain/Weight.java
+++ b/src/main/java/org/jhipster/health/domain/Weight.java
@@ -10,6 +10,7 @@ import javax.validation.constraints.NotNull;
 import java.io.Serializable;
 import java.time.ZonedDateTime;
 import java.util.Objects;
+import java.util.UUID;
 
 /**
  * A Weight.
@@ -23,9 +24,8 @@ public class Weight implements Serializable {
     private static final long serialVersionUID = 1L;
 
     @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "sequenceGenerator")
-    @SequenceGenerator(name = "sequenceGenerator")
-    private Long id;
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private UUID id;
 
     @NotNull
     @Column(name = "jhi_timestamp", nullable = false)
@@ -49,11 +49,11 @@ public class Weight implements Serializable {
 
     // jhipster-needle-entity-add-field - JHipster will add fields here, do not remove
 
-    public Long getId() {
+    public UUID getId() {
         return id;
     }
 
-    public void setId(Long id) {
+    public void setId(UUID id) {
         this.id = id;
     }
 

--- a/src/main/java/org/jhipster/health/repository/BloodPressureRepository.java
+++ b/src/main/java/org/jhipster/health/repository/BloodPressureRepository.java
@@ -10,13 +10,14 @@ import org.springframework.stereotype.Repository;
 import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.UUID;
 
 /**
  * Spring Data JPA repository for the BloodPressure entity.
  */
 @SuppressWarnings("unused")
 @Repository
-public interface BloodPressureRepository extends JpaRepository<BloodPressure, Long> {
+public interface BloodPressureRepository extends JpaRepository<BloodPressure, UUID> {
 
     @Query("select blood_pressure from BloodPressure blood_pressure where blood_pressure.user.login = ?#{principal.username} order by blood_pressure.timestamp desc")
     Page<BloodPressure> findByUserIsCurrentUser(Pageable pageable);

--- a/src/main/java/org/jhipster/health/repository/PersistenceAuditEventRepository.java
+++ b/src/main/java/org/jhipster/health/repository/PersistenceAuditEventRepository.java
@@ -7,11 +7,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.UUID;
 
 /**
  * Spring Data JPA repository for the PersistentAuditEvent entity.
  */
-public interface PersistenceAuditEventRepository extends JpaRepository<PersistentAuditEvent, Long> {
+public interface PersistenceAuditEventRepository extends JpaRepository<PersistentAuditEvent, UUID> {
 
     List<PersistentAuditEvent> findByPrincipal(String principal);
 

--- a/src/main/java/org/jhipster/health/repository/PointsRepository.java
+++ b/src/main/java/org/jhipster/health/repository/PointsRepository.java
@@ -9,13 +9,14 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.UUID;
 
 /**
  * Spring Data JPA repository for the Points entity.
  */
 @SuppressWarnings("unused")
 @Repository
-public interface PointsRepository extends JpaRepository<Points, Long> {
+public interface PointsRepository extends JpaRepository<Points, UUID> {
 
     @Query("select points from Points points where points.user.login = ?#{principal.username} order by points.date desc")
     Page<Points> findByUserIsCurrentUser(Pageable pageable);

--- a/src/main/java/org/jhipster/health/repository/PreferencesRepository.java
+++ b/src/main/java/org/jhipster/health/repository/PreferencesRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.*;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
+import java.util.UUID;
 
 
 /**
@@ -12,7 +13,7 @@ import java.util.Optional;
  */
 @SuppressWarnings("unused")
 @Repository
-public interface PreferencesRepository extends JpaRepository<Preferences, Long> {
+public interface PreferencesRepository extends JpaRepository<Preferences, UUID> {
 
     Optional<Preferences> findOneByUserLogin(String login);
 }

--- a/src/main/java/org/jhipster/health/repository/UserRepository.java
+++ b/src/main/java/org/jhipster/health/repository/UserRepository.java
@@ -11,12 +11,13 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 import java.util.Optional;
 import java.time.Instant;
+import java.util.UUID;
 
 /**
  * Spring Data JPA repository for the User entity.
  */
 @Repository
-public interface UserRepository extends JpaRepository<User, Long> {
+public interface UserRepository extends JpaRepository<User, UUID> {
 
     String USERS_BY_LOGIN_CACHE = "usersByLogin";
 
@@ -33,7 +34,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findOneByLogin(String login);
 
     @EntityGraph(attributePaths = "authorities")
-    Optional<User> findOneWithAuthoritiesById(Long id);
+    Optional<User> findOneWithAuthoritiesById(UUID id);
 
     @EntityGraph(attributePaths = "authorities")
     @Cacheable(cacheNames = USERS_BY_LOGIN_CACHE)

--- a/src/main/java/org/jhipster/health/repository/WeightRepository.java
+++ b/src/main/java/org/jhipster/health/repository/WeightRepository.java
@@ -9,13 +9,14 @@ import org.springframework.stereotype.Repository;
 
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.UUID;
 
 /**
  * Spring Data  repository for the Weight entity.
  */
 @SuppressWarnings("unused")
 @Repository
-public interface WeightRepository extends JpaRepository<Weight, Long> {
+public interface WeightRepository extends JpaRepository<Weight, UUID> {
 
     @Query("select weight from Weight weight where weight.user.login = ?#{principal.username} order by weight.timestamp desc")
     Page<Weight> findByUserIsCurrentUser(Pageable pageable);

--- a/src/main/java/org/jhipster/health/repository/search/BloodPressureSearchRepository.java
+++ b/src/main/java/org/jhipster/health/repository/search/BloodPressureSearchRepository.java
@@ -3,8 +3,10 @@ package org.jhipster.health.repository.search;
 import org.jhipster.health.domain.BloodPressure;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
 
+import java.util.UUID;
+
 /**
  * Spring Data Elasticsearch repository for the BloodPressure entity.
  */
-public interface BloodPressureSearchRepository extends ElasticsearchRepository<BloodPressure, Long> {
+public interface BloodPressureSearchRepository extends ElasticsearchRepository<BloodPressure, UUID> {
 }

--- a/src/main/java/org/jhipster/health/repository/search/PointsSearchRepository.java
+++ b/src/main/java/org/jhipster/health/repository/search/PointsSearchRepository.java
@@ -3,8 +3,10 @@ package org.jhipster.health.repository.search;
 import org.jhipster.health.domain.Points;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
 
+import java.util.UUID;
+
 /**
  * Spring Data Elasticsearch repository for the Points entity.
  */
-public interface PointsSearchRepository extends ElasticsearchRepository<Points, Long> {
+public interface PointsSearchRepository extends ElasticsearchRepository<Points, UUID> {
 }

--- a/src/main/java/org/jhipster/health/repository/search/PreferencesSearchRepository.java
+++ b/src/main/java/org/jhipster/health/repository/search/PreferencesSearchRepository.java
@@ -3,8 +3,10 @@ package org.jhipster.health.repository.search;
 import org.jhipster.health.domain.Preferences;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
 
+import java.util.UUID;
+
 /**
  * Spring Data Elasticsearch repository for the Preferences entity.
  */
-public interface PreferencesSearchRepository extends ElasticsearchRepository<Preferences, Long> {
+public interface PreferencesSearchRepository extends ElasticsearchRepository<Preferences, UUID> {
 }

--- a/src/main/java/org/jhipster/health/repository/search/UserSearchRepository.java
+++ b/src/main/java/org/jhipster/health/repository/search/UserSearchRepository.java
@@ -3,8 +3,10 @@ package org.jhipster.health.repository.search;
 import org.jhipster.health.domain.User;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
 
+import java.util.UUID;
+
 /**
  * Spring Data Elasticsearch repository for the User entity.
  */
-public interface UserSearchRepository extends ElasticsearchRepository<User, Long> {
+public interface UserSearchRepository extends ElasticsearchRepository<User, UUID> {
 }

--- a/src/main/java/org/jhipster/health/repository/search/WeightSearchRepository.java
+++ b/src/main/java/org/jhipster/health/repository/search/WeightSearchRepository.java
@@ -3,8 +3,10 @@ package org.jhipster.health.repository.search;
 import org.jhipster.health.domain.Weight;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
 
+import java.util.UUID;
+
 /**
  * Spring Data Elasticsearch repository for the Weight entity.
  */
-public interface WeightSearchRepository extends ElasticsearchRepository<Weight, Long> {
+public interface WeightSearchRepository extends ElasticsearchRepository<Weight, UUID> {
 }

--- a/src/main/java/org/jhipster/health/service/AuditEventService.java
+++ b/src/main/java/org/jhipster/health/service/AuditEventService.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
 import java.util.Optional;
+import java.util.UUID;
 
 /**
  * Service for managing audit events.
@@ -42,7 +43,7 @@ public class AuditEventService {
             .map(auditEventConverter::convertToAuditEvent);
     }
 
-    public Optional<AuditEvent> find(Long id) {
+    public Optional<AuditEvent> find(UUID id) {
         return Optional.ofNullable(persistenceAuditEventRepository.findById(id))
             .filter(Optional::isPresent)
             .map(Optional::get)

--- a/src/main/java/org/jhipster/health/service/UserService.java
+++ b/src/main/java/org/jhipster/health/service/UserService.java
@@ -264,7 +264,7 @@ public class UserService {
     }
 
     @Transactional(readOnly = true)
-    public Optional<User> getUserWithAuthorities(Long id) {
+    public Optional<User> getUserWithAuthorities(UUID id) {
         return userRepository.findOneWithAuthoritiesById(id);
     }
 

--- a/src/main/java/org/jhipster/health/service/dto/UserDTO.java
+++ b/src/main/java/org/jhipster/health/service/dto/UserDTO.java
@@ -11,6 +11,7 @@ import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.*;
 import java.time.Instant;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 /**
@@ -18,7 +19,7 @@ import java.util.stream.Collectors;
  */
 public class UserDTO {
 
-    private Long id;
+    private UUID id;
 
     @NotBlank
     @Pattern(regexp = Constants.LOGIN_REGEX)
@@ -75,11 +76,11 @@ public class UserDTO {
             .collect(Collectors.toSet());
     }
 
-    public Long getId() {
+    public UUID getId() {
         return id;
     }
 
-    public void setId(Long id) {
+    public void setId(UUID id) {
         this.id = id;
     }
 

--- a/src/main/java/org/jhipster/health/service/mapper/UserMapper.java
+++ b/src/main/java/org/jhipster/health/service/mapper/UserMapper.java
@@ -57,7 +57,7 @@ public class UserMapper {
             .collect(Collectors.toList());
     }
 
-    public User userFromId(Long id) {
+    public User userFromId(UUID id) {
         if (id == null) {
             return null;
         }

--- a/src/main/java/org/jhipster/health/web/rest/AuditResource.java
+++ b/src/main/java/org/jhipster/health/web/rest/AuditResource.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.*;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.List;
+import java.util.UUID;
 
 /**
  * REST controller for getting the audit events.
@@ -71,7 +72,7 @@ public class AuditResource {
      * @return the ResponseEntity with status 200 (OK) and the AuditEvent in body, or status 404 (Not Found)
      */
     @GetMapping("/{id:.+}")
-    public ResponseEntity<AuditEvent> get(@PathVariable Long id) {
+    public ResponseEntity<AuditEvent> get(@PathVariable UUID id) {
         return ResponseUtil.wrapOrNotFound(auditEventService.find(id));
     }
 }

--- a/src/main/java/org/jhipster/health/web/rest/BloodPressureResource.java
+++ b/src/main/java/org/jhipster/health/web/rest/BloodPressureResource.java
@@ -34,6 +34,7 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 import static org.elasticsearch.index.query.QueryBuilders.matchQuery;
 import static org.elasticsearch.index.query.QueryBuilders.queryStringQuery;
@@ -182,7 +183,7 @@ public class BloodPressureResource {
      */
     @GetMapping("/blood-pressures/{id}")
     @Timed
-    public ResponseEntity<?> getBloodPressure(@PathVariable Long id) {
+    public ResponseEntity<?> getBloodPressure(@PathVariable UUID id) {
         log.debug("REST request to get BloodPressure : {}", id);
         Optional<BloodPressure> bloodPressure = bloodPressureRepository.findById(id);
         if (bloodPressure.isPresent() && bloodPressure.get().getUser() != null &&
@@ -200,7 +201,7 @@ public class BloodPressureResource {
      */
     @DeleteMapping("/blood-pressures/{id}")
     @Timed
-    public ResponseEntity<?> deleteBloodPressure(@PathVariable Long id) {
+    public ResponseEntity<?> deleteBloodPressure(@PathVariable UUID id) {
         log.debug("REST request to delete BloodPressure : {}", id);
         Optional<BloodPressure> bloodPressure = bloodPressureRepository.findById(id);
         if (bloodPressure.isPresent() && bloodPressure.get().getUser() != null &&

--- a/src/main/java/org/jhipster/health/web/rest/PointsResource.java
+++ b/src/main/java/org/jhipster/health/web/rest/PointsResource.java
@@ -34,6 +34,7 @@ import java.time.YearMonth;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 import static org.elasticsearch.index.query.QueryBuilders.matchQuery;
 import static org.elasticsearch.index.query.QueryBuilders.queryStringQuery;
@@ -203,7 +204,7 @@ public class PointsResource {
      */
     @GetMapping("/points/{id}")
     @Timed
-    public ResponseEntity<?> getPoints(@PathVariable Long id) {
+    public ResponseEntity<?> getPoints(@PathVariable UUID id) {
         log.debug("REST request to get Points : {}", id);
         Optional<Points> points = pointsRepository.findById(id);
         if (points.isPresent() && points.get().getUser() != null &&
@@ -221,7 +222,7 @@ public class PointsResource {
      */
     @DeleteMapping("/points/{id}")
     @Timed
-    public ResponseEntity<?> deletePoints(@PathVariable Long id) {
+    public ResponseEntity<?> deletePoints(@PathVariable UUID id) {
         log.debug("REST request to delete Points : {}", id);
         Optional<Points> points = pointsRepository.findById(id);
         if (points.isPresent() && points.get().getUser() != null &&

--- a/src/main/java/org/jhipster/health/web/rest/PreferencesResource.java
+++ b/src/main/java/org/jhipster/health/web/rest/PreferencesResource.java
@@ -25,6 +25,7 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -158,7 +159,7 @@ public class PreferencesResource {
      */
     @GetMapping("/preferences/{id}")
     @Timed
-    public ResponseEntity<?> getPreferences(@PathVariable Long id) {
+    public ResponseEntity<?> getPreferences(@PathVariable UUID id) {
         log.debug("REST request to get Preferences : {}", id);
         Optional<Preferences> preferences = preferencesRepository.findById(id);
         if (preferences.isPresent() && preferences.get().getUser() != null &&
@@ -176,7 +177,7 @@ public class PreferencesResource {
      */
     @DeleteMapping("/preferences/{id}")
     @Timed
-    public ResponseEntity<?> deletePreferences(@PathVariable Long id) {
+    public ResponseEntity<?> deletePreferences(@PathVariable UUID id) {
         log.debug("REST request to delete Preferences : {}", id);
         Optional<Preferences> preferences = preferencesRepository.findById(id);
         if (preferences.isPresent() && preferences.get().getUser() != null &&

--- a/src/main/java/org/jhipster/health/web/rest/WeightResource.java
+++ b/src/main/java/org/jhipster/health/web/rest/WeightResource.java
@@ -31,6 +31,7 @@ import java.time.*;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -190,7 +191,7 @@ public class WeightResource {
      */
     @GetMapping("/weights/{id}")
     @Timed
-    public ResponseEntity<?> getWeight(@PathVariable Long id) {
+    public ResponseEntity<?> getWeight(@PathVariable UUID id) {
         log.debug("REST request to get Weight : {}", id);
         Optional<Weight> weight = weightRepository.findById(id);
         if (weight.isPresent() && weight.get().getUser() != null &&
@@ -208,7 +209,7 @@ public class WeightResource {
      */
     @DeleteMapping("/weights/{id}")
     @Timed
-    public ResponseEntity<?> deleteWeight(@PathVariable Long id) {
+    public ResponseEntity<?> deleteWeight(@PathVariable UUID id) {
         log.debug("REST request to delete Weight : {}", id);
         Optional<Weight> weight = weightRepository.findById(id);
         if (weight.isPresent() && weight.get().getUser() != null &&

--- a/src/main/resources/config/liquibase/changelog/20190330115000_migrate_from_v5.xml
+++ b/src/main/resources/config/liquibase/changelog/20190330115000_migrate_from_v5.xml
@@ -6,7 +6,7 @@
     <property name="uuid_function" value="uid.uuid_generate_v4()" dbms="postgresql"/>
     <property name="uuid_function" value="RANDOM_UUID()" dbms="h2"/>
 
-    <changeSet author="mraible" id="1">
+    <changeSet id="1" author="mraible">
         <modifyDataType columnName="id" newDataType="${uuid_type}" tableName="jhi_user"/>
         <!--addDefaultValue columnName="id" defaultValueComputed="${uuid_function}" tableName="jhi_user"/-->
         <modifyDataType columnName="user_id" newDataType="${uuid_type}" tableName="jhi_user_authority"/>
@@ -14,5 +14,13 @@
         <modifyDataType columnName="user_id" newDataType="${uuid_type}" tableName="points"/>
         <modifyDataType columnName="user_id" newDataType="${uuid_type}" tableName="preferences"/>
         <modifyDataType columnName="user_id" newDataType="${uuid_type}" tableName="weight"/>
+    </changeSet>
+    <changeSet id="2" author="mraible">
+        <modifyDataType columnName="id" newDataType="${uuid_type}" tableName="blood_pressure"/>
+        <modifyDataType columnName="event_id" newDataType="${uuid_type}" tableName="jhi_persistent_audit_event"/>
+        <modifyDataType columnName="event_id" newDataType="${uuid_type}" tableName="jhi_persistent_audit_evt_data"/>
+        <modifyDataType columnName="id" newDataType="${uuid_type}" tableName="points"/>
+        <modifyDataType columnName="id" newDataType="${uuid_type}" tableName="preferences"/>
+        <modifyDataType columnName="id" newDataType="${uuid_type}" tableName="weight"/>
     </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/config/liquibase/changelog/20190330115000_migrate_from_v5.xml
+++ b/src/main/resources/config/liquibase/changelog/20190330115000_migrate_from_v5.xml
@@ -1,0 +1,18 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
+    <property name="uuid_type" value="uuid" dbms="postgresql,h2"/>
+    <property name="uuid_function" value="uid.uuid_generate_v4()" dbms="postgresql"/>
+    <property name="uuid_function" value="RANDOM_UUID()" dbms="h2"/>
+
+    <changeSet author="mraible" id="1">
+        <modifyDataType columnName="id" newDataType="${uuid_type}" tableName="jhi_user"/>
+        <!--addDefaultValue columnName="id" defaultValueComputed="${uuid_function}" tableName="jhi_user"/-->
+        <modifyDataType columnName="user_id" newDataType="${uuid_type}" tableName="jhi_user_authority"/>
+        <modifyDataType columnName="user_id" newDataType="${uuid_type}" tableName="blood_pressure"/>
+        <modifyDataType columnName="user_id" newDataType="${uuid_type}" tableName="points"/>
+        <modifyDataType columnName="user_id" newDataType="${uuid_type}" tableName="preferences"/>
+        <modifyDataType columnName="user_id" newDataType="${uuid_type}" tableName="weight"/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -16,5 +16,6 @@
     <include file="config/liquibase/changelog/20170725033721_added_entity_constraints_Preferences.xml" relativeToChangelogFile="false"/>
     <include file="config/liquibase/changelog/20160831021230_added_entity_constraints_BloodPressure.xml" relativeToChangelogFile="false"/>
     <include file="config/liquibase/changelog/20181013183900_migrate_from_v4.xml" relativeToChangelogFile="false"/>
+    <include file="config/liquibase/changelog/20190330115000_migrate_from_v5.xml" relativeToChangelogFile="false"/>
     <!-- jhipster-needle-liquibase-add-constraints-changelog - JHipster will add liquibase constraints changelogs here -->
 </databaseChangeLog>

--- a/src/test/java/org/jhipster/health/web/rest/AuditResourceIntTest.java
+++ b/src/test/java/org/jhipster/health/web/rest/AuditResourceIntTest.java
@@ -21,6 +21,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
+import java.util.UUID;
 
 import static org.hamcrest.Matchers.hasItem;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -140,7 +141,7 @@ public class AuditResourceIntTest {
     @Test
     public void getNonExistingAudit() throws Exception {
         // Get the audit
-        restAuditMockMvc.perform(get("/management/audits/{id}", Long.MAX_VALUE))
+        restAuditMockMvc.perform(get("/management/audits/{id}", UUID.randomUUID()))
             .andExpect(status().isNotFound());
     }
 }

--- a/src/test/java/org/jhipster/health/web/rest/BloodPressureResourceIntTest.java
+++ b/src/test/java/org/jhipster/health/web/rest/BloodPressureResourceIntTest.java
@@ -37,6 +37,7 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 
 import static org.hamcrest.Matchers.hasSize;
 import static org.jhipster.health.web.rest.TestUtil.sameInstant;
@@ -170,7 +171,7 @@ public class BloodPressureResourceIntTest {
         int databaseSizeBeforeCreate = bloodPressureRepository.findAll().size();
 
         // Create the BloodPressure with an existing ID
-        bloodPressure.setId(1L);
+        bloodPressure.setId(UUID.randomUUID());
 
         // An entity with an existing ID cannot be created, so this API call must fail
         restBloodPressureMockMvc.perform(post("/api/blood-pressures")
@@ -256,7 +257,7 @@ public class BloodPressureResourceIntTest {
             .with(user("admin").roles("ADMIN")))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
-            .andExpect(jsonPath("$.[*].id").value(hasItem(bloodPressure.getId().intValue())))
+            .andExpect(jsonPath("$.[*].id").value(hasItem(bloodPressure.getId().toString())))
             .andExpect(jsonPath("$.[*].timestamp").value(hasItem(sameInstant(DEFAULT_TIMESTAMP))))
             .andExpect(jsonPath("$.[*].systolic").value(hasItem(DEFAULT_SYSTOLIC)))
             .andExpect(jsonPath("$.[*].diastolic").value(hasItem(DEFAULT_DIASTOLIC)));
@@ -272,7 +273,7 @@ public class BloodPressureResourceIntTest {
         restBloodPressureMockMvc.perform(get("/api/blood-pressures/{id}", bloodPressure.getId()))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
-            .andExpect(jsonPath("$.id").value(bloodPressure.getId().intValue()))
+            .andExpect(jsonPath("$.id").value(bloodPressure.getId().toString()))
             .andExpect(jsonPath("$.timestamp").value(sameInstant(DEFAULT_TIMESTAMP)))
             .andExpect(jsonPath("$.systolic").value(DEFAULT_SYSTOLIC))
             .andExpect(jsonPath("$.diastolic").value(DEFAULT_DIASTOLIC));
@@ -282,7 +283,7 @@ public class BloodPressureResourceIntTest {
     @Transactional
     public void getNonExistingBloodPressure() throws Exception {
         // Get the bloodPressure
-        restBloodPressureMockMvc.perform(get("/api/blood-pressures/{id}", Long.MAX_VALUE))
+        restBloodPressureMockMvc.perform(get("/api/blood-pressures/{id}", UUID.randomUUID()))
             .andExpect(status().isNotFound());
     }
 
@@ -381,7 +382,7 @@ public class BloodPressureResourceIntTest {
         restBloodPressureMockMvc.perform(get("/api/_search/blood-pressures?query=id:" + bloodPressure.getId()))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
-            .andExpect(jsonPath("$.[*].id").value(hasItem(bloodPressure.getId().intValue())))
+            .andExpect(jsonPath("$.[*].id").value(hasItem(bloodPressure.getId().toString())))
             .andExpect(jsonPath("$.[*].timestamp").value(hasItem(sameInstant(DEFAULT_TIMESTAMP))))
             .andExpect(jsonPath("$.[*].systolic").value(hasItem(DEFAULT_SYSTOLIC)))
             .andExpect(jsonPath("$.[*].diastolic").value(hasItem(DEFAULT_DIASTOLIC)));
@@ -392,11 +393,11 @@ public class BloodPressureResourceIntTest {
     public void equalsVerifier() throws Exception {
         TestUtil.equalsVerifier(BloodPressure.class);
         BloodPressure bloodPressure1 = new BloodPressure();
-        bloodPressure1.setId(1L);
+        bloodPressure1.setId(UUID.randomUUID());
         BloodPressure bloodPressure2 = new BloodPressure();
         bloodPressure2.setId(bloodPressure1.getId());
         assertThat(bloodPressure1).isEqualTo(bloodPressure2);
-        bloodPressure2.setId(2L);
+        bloodPressure2.setId(UUID.randomUUID());
         assertThat(bloodPressure1).isNotEqualTo(bloodPressure2);
         bloodPressure1.setId(null);
         assertThat(bloodPressure1).isNotEqualTo(bloodPressure2);

--- a/src/test/java/org/jhipster/health/web/rest/PointsResourceIntTest.java
+++ b/src/test/java/org/jhipster/health/web/rest/PointsResourceIntTest.java
@@ -36,6 +36,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoField;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 
 import static org.elasticsearch.index.query.QueryBuilders.queryStringQuery;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -178,7 +179,7 @@ public class PointsResourceIntTest {
         int databaseSizeBeforeCreate = pointsRepository.findAll().size();
 
         // Create the Points with an existing ID
-        points.setId(1L);
+        points.setId(UUID.randomUUID());
 
         // An entity with an existing ID cannot be created, so this API call must fail
         restPointsMockMvc.perform(post("/api/points")
@@ -228,7 +229,7 @@ public class PointsResourceIntTest {
             .with(user("admin").roles("ADMIN")))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
-            .andExpect(jsonPath("$.[*].id").value(hasItem(points.getId().intValue())))
+            .andExpect(jsonPath("$.[*].id").value(hasItem(points.getId().toString())))
             .andExpect(jsonPath("$.[*].date").value(hasItem(DEFAULT_DATE.toString())))
             .andExpect(jsonPath("$.[*].exercise").value(hasItem(DEFAULT_EXERCISE)))
             .andExpect(jsonPath("$.[*].meals").value(hasItem(DEFAULT_MEALS)))
@@ -246,7 +247,7 @@ public class PointsResourceIntTest {
         restPointsMockMvc.perform(get("/api/points/{id}", points.getId()))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
-            .andExpect(jsonPath("$.id").value(points.getId().intValue()))
+            .andExpect(jsonPath("$.id").value(points.getId().toString()))
             .andExpect(jsonPath("$.date").value(DEFAULT_DATE.toString()))
             .andExpect(jsonPath("$.exercise").value(DEFAULT_EXERCISE))
             .andExpect(jsonPath("$.meals").value(DEFAULT_MEALS))
@@ -258,7 +259,7 @@ public class PointsResourceIntTest {
     @Transactional
     public void getNonExistingPoints() throws Exception {
         // Get the points
-        restPointsMockMvc.perform(get("/api/points/{id}", Long.MAX_VALUE))
+        restPointsMockMvc.perform(get("/api/points/{id}", UUID.randomUUID()))
             .andExpect(status().isNotFound());
     }
 
@@ -359,7 +360,7 @@ public class PointsResourceIntTest {
         restPointsMockMvc.perform(get("/api/_search/points?query=id:" + points.getId()))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
-            .andExpect(jsonPath("$.[*].id").value(hasItem(points.getId().intValue())))
+            .andExpect(jsonPath("$.[*].id").value(hasItem(points.getId().toString())))
             .andExpect(jsonPath("$.[*].date").value(hasItem(DEFAULT_DATE.toString())))
             .andExpect(jsonPath("$.[*].exercise").value(hasItem(DEFAULT_EXERCISE)))
             .andExpect(jsonPath("$.[*].meals").value(hasItem(DEFAULT_MEALS)))
@@ -372,11 +373,11 @@ public class PointsResourceIntTest {
     public void equalsVerifier() throws Exception {
         TestUtil.equalsVerifier(Points.class);
         Points points1 = new Points();
-        points1.setId(1L);
+        points1.setId(UUID.randomUUID());
         Points points2 = new Points();
         points2.setId(points1.getId());
         assertThat(points1).isEqualTo(points2);
-        points2.setId(2L);
+        points2.setId(UUID.randomUUID());
         assertThat(points1).isNotEqualTo(points2);
         points1.setId(null);
         assertThat(points1).isNotEqualTo(points2);

--- a/src/test/java/org/jhipster/health/web/rest/PreferencesResourceIntTest.java
+++ b/src/test/java/org/jhipster/health/web/rest/PreferencesResourceIntTest.java
@@ -27,6 +27,7 @@ import org.springframework.web.context.WebApplicationContext;
 import javax.persistence.EntityManager;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.elasticsearch.index.query.QueryBuilders.queryStringQuery;
@@ -150,7 +151,7 @@ public class PreferencesResourceIntTest {
         int databaseSizeBeforeCreate = preferencesRepository.findAll().size();
 
         // Create the Preferences with an existing ID
-        preferences.setId(1L);
+        preferences.setId(UUID.randomUUID());
 
         // An entity with an existing ID cannot be created, so this API call must fail
         restPreferencesMockMvc.perform(post("/api/preferences")
@@ -219,7 +220,7 @@ public class PreferencesResourceIntTest {
             .with(user("admin").roles("ADMIN")))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
-            .andExpect(jsonPath("$.[*].id").value(hasItem(preferences.getId().intValue())))
+            .andExpect(jsonPath("$.[*].id").value(hasItem(preferences.getId().toString())))
             .andExpect(jsonPath("$.[*].weeklyGoal").value(hasItem(DEFAULT_WEEKLY_GOAL)))
             .andExpect(jsonPath("$.[*].weightUnits").value(hasItem(DEFAULT_WEIGHT_UNITS.toString())));
     }
@@ -234,7 +235,7 @@ public class PreferencesResourceIntTest {
         restPreferencesMockMvc.perform(get("/api/preferences/{id}", preferences.getId()))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
-            .andExpect(jsonPath("$.id").value(preferences.getId().intValue()))
+            .andExpect(jsonPath("$.id").value(preferences.getId().toString()))
             .andExpect(jsonPath("$.weeklyGoal").value(DEFAULT_WEEKLY_GOAL))
             .andExpect(jsonPath("$.weightUnits").value(DEFAULT_WEIGHT_UNITS.toString()));
     }
@@ -243,7 +244,7 @@ public class PreferencesResourceIntTest {
     @Transactional
     public void getNonExistingPreferences() throws Exception {
         // Get the preferences
-        restPreferencesMockMvc.perform(get("/api/preferences/{id}", Long.MAX_VALUE))
+        restPreferencesMockMvc.perform(get("/api/preferences/{id}", UUID.randomUUID()))
             .andExpect(status().isNotFound());
     }
 
@@ -338,7 +339,7 @@ public class PreferencesResourceIntTest {
         restPreferencesMockMvc.perform(get("/api/_search/preferences?query=id:" + preferences.getId()))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
-            .andExpect(jsonPath("$.[*].id").value(hasItem(preferences.getId().intValue())))
+            .andExpect(jsonPath("$.[*].id").value(preferences.getId().toString()))
             .andExpect(jsonPath("$.[*].weeklyGoal").value(hasItem(DEFAULT_WEEKLY_GOAL)))
             .andExpect(jsonPath("$.[*].weightUnits").value(hasItem(DEFAULT_WEIGHT_UNITS.toString())));
     }
@@ -348,11 +349,11 @@ public class PreferencesResourceIntTest {
     public void equalsVerifier() throws Exception {
         TestUtil.equalsVerifier(Preferences.class);
         Preferences preferences1 = new Preferences();
-        preferences1.setId(1L);
+        preferences1.setId(UUID.randomUUID());
         Preferences preferences2 = new Preferences();
         preferences2.setId(preferences1.getId());
         assertThat(preferences1).isEqualTo(preferences2);
-        preferences2.setId(2L);
+        preferences2.setId(UUID.randomUUID());
         assertThat(preferences1).isNotEqualTo(preferences2);
         preferences1.setId(null);
         assertThat(preferences1).isNotEqualTo(preferences2);

--- a/src/test/java/org/jhipster/health/web/rest/PreferencesResourceIntTest.java
+++ b/src/test/java/org/jhipster/health/web/rest/PreferencesResourceIntTest.java
@@ -339,7 +339,7 @@ public class PreferencesResourceIntTest {
         restPreferencesMockMvc.perform(get("/api/_search/preferences?query=id:" + preferences.getId()))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
-            .andExpect(jsonPath("$.[*].id").value(preferences.getId().toString()))
+            .andExpect(jsonPath("$.[*].id").value(hasItem(preferences.getId().toString())))
             .andExpect(jsonPath("$.[*].weeklyGoal").value(hasItem(DEFAULT_WEEKLY_GOAL)))
             .andExpect(jsonPath("$.[*].weightUnits").value(hasItem(DEFAULT_WEIGHT_UNITS.toString())));
     }

--- a/src/test/java/org/jhipster/health/web/rest/UserResourceIntTest.java
+++ b/src/test/java/org/jhipster/health/web/rest/UserResourceIntTest.java
@@ -49,7 +49,7 @@ public class UserResourceIntTest {
     private static final String DEFAULT_LOGIN = "johndoe";
     private static final String UPDATED_LOGIN = "jhipster";
 
-    private static final Long DEFAULT_ID = 1L;
+    private static final UUID DEFAULT_ID = UUID.randomUUID();
 
     private static final String DEFAULT_PASSWORD = "passjohndoe";
     private static final String UPDATED_PASSWORD = "passjhipster";
@@ -187,7 +187,7 @@ public class UserResourceIntTest {
         int databaseSizeBeforeCreate = userRepository.findAll().size();
 
         ManagedUserVM managedUserVM = new ManagedUserVM();
-        managedUserVM.setId(1L);
+        managedUserVM.setId(UUID.randomUUID());
         managedUserVM.setLogin(DEFAULT_LOGIN);
         managedUserVM.setPassword(DEFAULT_PASSWORD);
         managedUserVM.setFirstName(DEFAULT_FIRSTNAME);
@@ -531,11 +531,11 @@ public class UserResourceIntTest {
     public void testUserEquals() throws Exception {
         TestUtil.equalsVerifier(User.class);
         User user1 = new User();
-        user1.setId(1L);
+        user1.setId(UUID.randomUUID());
         User user2 = new User();
         user2.setId(user1.getId());
         assertThat(user1).isEqualTo(user2);
-        user2.setId(2L);
+        user2.setId(UUID.randomUUID());
         assertThat(user1).isNotEqualTo(user2);
         user1.setId(null);
         assertThat(user1).isNotEqualTo(user2);

--- a/src/test/java/org/jhipster/health/web/rest/WeightResourceIntTest.java
+++ b/src/test/java/org/jhipster/health/web/rest/WeightResourceIntTest.java
@@ -38,6 +38,7 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 
 import static org.hamcrest.Matchers.hasSize;
 import static org.jhipster.health.web.rest.TestUtil.sameInstant;
@@ -167,7 +168,7 @@ public class WeightResourceIntTest {
         int databaseSizeBeforeCreate = weightRepository.findAll().size();
 
         // Create the Weight with an existing ID
-        weight.setId(1L);
+        weight.setId(UUID.randomUUID());
 
         // An entity with an existing ID cannot be created, so this API call must fail
         restWeightMockMvc.perform(post("/api/weights")
@@ -236,9 +237,9 @@ public class WeightResourceIntTest {
             .with(user("admin").roles("ADMIN")))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
-            .andExpect(jsonPath("$.[*].id").value(hasItem(weight.getId().intValue())))
+            .andExpect(jsonPath("$.[*].id").value(hasItem(weight.getId().toString())))
             .andExpect(jsonPath("$.[*].timestamp").value(hasItem(sameInstant(DEFAULT_TIMESTAMP))))
-            .andExpect(jsonPath("$.[*].weight").value(hasItem(DEFAULT_WEIGHT.doubleValue())));
+            .andExpect(jsonPath("$.[*].weight").value(hasItem(DEFAULT_WEIGHT)));
     }
 
     @Test
@@ -251,16 +252,16 @@ public class WeightResourceIntTest {
         restWeightMockMvc.perform(get("/api/weights/{id}", weight.getId()))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
-            .andExpect(jsonPath("$.id").value(weight.getId().intValue()))
+            .andExpect(jsonPath("$.id").value(weight.getId().toString()))
             .andExpect(jsonPath("$.timestamp").value(sameInstant(DEFAULT_TIMESTAMP)))
-            .andExpect(jsonPath("$.weight").value(DEFAULT_WEIGHT.doubleValue()));
+            .andExpect(jsonPath("$.weight").value(DEFAULT_WEIGHT));
     }
 
     @Test
     @Transactional
     public void getNonExistingWeight() throws Exception {
         // Get the weight
-        restWeightMockMvc.perform(get("/api/weights/{id}", Long.MAX_VALUE))
+        restWeightMockMvc.perform(get("/api/weights/{id}", UUID.randomUUID()))
             .andExpect(status().isNotFound());
     }
 
@@ -356,7 +357,7 @@ public class WeightResourceIntTest {
         restWeightMockMvc.perform(get("/api/_search/weights?query=id:" + weight.getId()))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
-            .andExpect(jsonPath("$.[*].id").value(hasItem(weight.getId().intValue())))
+            .andExpect(jsonPath("$.[*].id").value(hasItem(weight.getId().toString())))
             .andExpect(jsonPath("$.[*].timestamp").value(hasItem(sameInstant(DEFAULT_TIMESTAMP))))
             .andExpect(jsonPath("$.[*].weight").value(hasItem(DEFAULT_WEIGHT)));
     }
@@ -366,11 +367,11 @@ public class WeightResourceIntTest {
     public void equalsVerifier() throws Exception {
         TestUtil.equalsVerifier(Weight.class);
         Weight weight1 = new Weight();
-        weight1.setId(1L);
+        weight1.setId(UUID.randomUUID());
         Weight weight2 = new Weight();
         weight2.setId(weight1.getId());
         assertThat(weight1).isEqualTo(weight2);
-        weight2.setId(2L);
+        weight2.setId(UUID.randomUUID());
         assertThat(weight1).isNotEqualTo(weight2);
         weight1.setId(null);
         assertThat(weight1).isNotEqualTo(weight2);


### PR DESCRIPTION
This is to fix [#50](https://github.com/mraible/21-points/issues/50) and because [Heroku recommends it](https://devcenter.heroku.com/articles/preparing-a-spring-boot-app-for-production-on-heroku#use-uuids-for-all-postgres-primary-keys).